### PR TITLE
Brightcove doesn't always return valid JSON, thus causes crashes.

### DIFF
--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -1,5 +1,5 @@
 
-// api reference: http://docs.brightcove.com/en/media/
+// api reference: http://docs.brightcove.com/en/index.html
 // object reference: http://support.brightcove.com/en/docs/media-api-objects-reference
 // test token taken from brightcove example: 0Z2dtxTdJAxtbZ-d0U7Bhio2V1Rhr5Iafl5FFtDPY8E.
 //
@@ -127,8 +127,14 @@ api.prototype.makeRequest = function makeRequest(command, options, callback) {
 		});
 
 		response.on('end', function(err) {
+			try {
+				var json = JSON.parse(data.toString());
+			}
+			catch (jsonError){
+				// Pass along the error from JSON.parse
+				err = jsonError;
+			}
 
-			var json = JSON.parse(data.toString());
 			var error = self.handleApiErrors(err, json);
 
 			// emit response


### PR DESCRIPTION
## Description
The brightcove API is very poor sometimes and returns invalid JSON in some cases, causing application crashes. Wrapping JSON.parse in a try/catch block can help alleviate the issues.