### PR TITLE
Added support for other default sorts from Brightcove Media API

### DIFF
--- a/lib/sortOrder.js
+++ b/lib/sortOrder.js
@@ -10,6 +10,11 @@ sortOrder.prototype.creationDate = function creationDate() {
 	return this._options;
 }
 
+sortOrder.prototype.displayName = function displayName() {
+	this._options.sort_by = 'DISPLAY_NAME';
+	return this._options;
+}
+
 sortOrder.prototype.modifiedDate = function modifiedDate() {
 	this._options.sort_by = 'MODIFIED_DATE';
 	return this._options;
@@ -22,6 +27,21 @@ sortOrder.prototype.totalPlays = function totalPlays() {
 
 sortOrder.prototype.totalPlaysOfLastWeek = function totalPlaysOfLastWeek() {
 	this._options.sort_by = 'PLAYS_TRAILING_WEEK';
+	return this._options;
+}
+
+sortOrder.prototype.publishDate = function publishDate() {
+	this._options.sort_by = 'PUBLISH_DATE';
+	return this._options;
+}
+
+sortOrder.prototype.referenceId = function referenceId() {
+	this._options.sort_by = 'REFERENCE_ID';
+	return this._options;
+}
+
+sortOrder.prototype.startDate = function startDate() {
+	this._options.sort_by = 'START_DATE';
 	return this._options;
 }
 

--- a/lib/videoFields.js
+++ b/lib/videoFields.js
@@ -49,6 +49,10 @@ videoFields.prototype.lastModifiedDate = function lastModifiedDate() {
 	return this.addVideoField('lastModifiedDate');
 }
 
+videoFields.prototype.startDate = function startDate() {
+	return this.addVideoField('startDate');
+}
+
 videoFields.prototype.linkUrl = function linkUrl() {
 	return this.addVideoField('linkURL');
 }
@@ -125,6 +129,7 @@ videoFields.prototype.allFields = function allFields() {
 	this.creationDate();
 	this.publishedDate();
 	this.lastModifiedDate();
+	this.startDate();
 	this.linkUrl();
 	this.linkText();
 	this.tags();


### PR DESCRIPTION
Thanks for building this...I have added just a few changes that will help our team utilize it for our needs. What we needed most was the sort by publish_date but I went ahead and added in the remaining sorts in case others could use them as well.