### PR TITLE
adjust query for multiple search terms

### DIFF
--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -49,9 +49,18 @@ var buildUrl = function buildUrl(command, options) {
 			}
 		}
 
+		// Multiple search terms http://docs.brightcove.com/en/video-cloud/media/guides/search_videos-guide.html#multipleTerms
+		var multipleSearchTerms = ["any", "all", "none"];
+
 		for (var option in options) {
 			if (typeof options[option] !== 'function')
-				url.addQueryParam(option, options[option]);
+			  if (Array.isArray(options[option]) && multipleSearchTerms.indexOf(option) != -1) {
+					for (var item in options[option]) {
+						url.addQueryParam(option, options[option][item]);
+					}
+				} else {
+					url.addQueryParam(option, options[option]);
+				}
 		}
 	}
 	

--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -12,6 +12,8 @@ var events = require('events'),
 	Options = require('./options'),
 	Playlist = require('./playlist');
 
+// Multiple search terms http://docs.brightcove.com/en/video-cloud/media/guides/search_videos-guide.html#multipleTerms
+var multipleSearchTerms = ["any", "all", "none"];
 
 var api = function MediaApi(token) {
 
@@ -48,9 +50,6 @@ var buildUrl = function buildUrl(command, options) {
 				delete options.sort_order;
 			}
 		}
-
-		// Multiple search terms http://docs.brightcove.com/en/video-cloud/media/guides/search_videos-guide.html#multipleTerms
-		var multipleSearchTerms = ["any", "all", "none"];
 
 		for (var option in options) {
 			if (typeof options[option] !== 'function')


### PR DESCRIPTION
Found one small adjustment...according to Brightcove at [http://docs.brightcove.com/en/video-cloud/media/guides/search_videos-guide.html#multipleTerms](url)

> One of the most commonly misunderstood aspects of search_videos is how you search on multiple terms. Say, for instance, that you want to return videos that have all of the following tags: bird; air; nature. To do this, you must include a separate all parameter for each search term, like this:

```
//api.brightcove.com/services/library?command=search_videos
&all=tag:bird&all=tag:air&all=tag:nature
&video_fields=id,name,shortDescription&get_item_count=true
&token=ZY4Ls9Hq6LCBgleGDTaFRDLWWBC8uoXQun0xEEXtlDUHBDPZBCOzbw..
```

This pull should identify when you are attempting to pass an array of search terms and adjust the query accordingly without affecting other query params that are passed as arrays and Brightcove wants them separated by commas in the request.