### PR TITLE
Sometimes brightcove sends back null as the body

### DIFF
--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -170,7 +170,7 @@ api.prototype.makeRequest = function makeRequest(command, options, callback, pro
 
 			// kick off callback, if needed
 			if (typeof callback === 'function') {
-				callback(error || body.error, body);
+				callback(error, body);
 			}
 		}
 	});

--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -163,9 +163,10 @@ api.prototype.makeRequest = function makeRequest(command, options, callback, pro
 				callback(error, body);
 			}
 		} else {
+			error = error || (body === null ? undefined : body.error);
 			// handle those pesky http request errors.
-			self.handleApiErrors(error || body.error, body);
-			self.emit(command, error || body.error, body);
+			self.handleApiErrors(error, body);
+			self.emit(command, error, body);
 
 			// kick off callback, if needed
 			if (typeof callback === 'function') {

--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -154,7 +154,7 @@ api.prototype.makeRequest = function makeRequest(command, options, callback, pro
 		} catch(e) {
 			// Not a JSON response
 		}
-		if (!error && response.statusCode == 200 && !body.error) {
+		if (!error && response.statusCode == 200 && body && !body.error) {
 			// emit response
 			self.emit(command, error, body);
 


### PR DESCRIPTION
This was encountered when calling find_video_by_id, no reasoning that I know of, the same request works most of the time. This change will protect against an exception