### PR TITLE
add includingFiltered option

### DIFF
--- a/lib/mediaApi.js
+++ b/lib/mediaApi.js
@@ -98,11 +98,16 @@ api.prototype.commands = {
 		// Video Read APIs
 		find_all_videos: 'find_all_videos',
 		find_video_by_id: 'find_video_by_id',
+		find_video_by_id_unfiltered: 'find_video_by_id_unfiltered',
 		find_videos_by_ids: 'find_videos_by_ids',
+		find_videos_by_ids_unfiltered: 'find_videos_by_ids_unfiltered',
 		find_related_videos: 'find_related_videos',
 		find_video_by_reference_id: 'find_video_by_reference_id',
+		find_video_by_reference_id_unfiltered: 'find_video_by_reference_id_unfiltered',
 		find_videos_by_reference_ids: 'find_videos_by_reference_ids',
+		find_videos_by_reference_ids_unfiltered: 'find_videos_by_reference_ids_unfiltered',
 		search_videos: 'search_videos',
+		search_videos_unfiltered: 'search_videos_unfiltered',
 
 		// Playlist Read APIs
 		find_all_playlists: 'find_all_playlists',
@@ -264,28 +269,24 @@ api.prototype.withOptions = function withOptions() {
 	return new Options();
 }
 
-
 api.prototype.withDefaultOptions = function withDefaultOptions() {
 	return new Options()
 			.includingCountOfItems()
 			.includingVideoField().defaults();
 }
 
-
 api.prototype.findAllVideos = function findAllVideos(options, callback) {
 
 	return this.makeRequest(this.commands.read.find_all_videos, options, callback);
 }
-
 
 api.prototype.findVideoById = function findVideoById(videoId, options, callback) {
 
 	var opts = options || new Options();
 	opts.video_id = videoId;
 
-	return this.makeRequest(this.commands.read.find_video_by_id, opts, callback);
+	return this.makeRequest(opts.useUnfilteredMethod ? this.commands.read.find_video_by_id_unfiltered : this.commands.read.find_video_by_id, opts, callback);
 }
-
 
 api.prototype.findVideosByIds = function findVideosByIds(videoIds, options, callback) {
 
@@ -294,9 +295,8 @@ api.prototype.findVideosByIds = function findVideosByIds(videoIds, options, call
 	if (Array.isArray(videoIds))
 		opts.video_ids = videoIds;
 
-	return this.makeRequest(this.commands.read.find_videos_by_ids, opts, callback);
+	return this.makeRequest(opts.useUnfilteredMethod ? this.commands.read.find_videos_by_ids_unfiltered : this.commands.read.find_videos_by_ids, opts, callback);
 }
-
 
 api.prototype.findRelatedVideos = function findRelatedVideos(videoId, referenceId, options, callback) {
 
@@ -311,15 +311,13 @@ api.prototype.findRelatedVideos = function findRelatedVideos(videoId, referenceI
 	return this.makeRequest(this.commands.read.find_related_videos, opts, callback);
 }
 
-
 api.prototype.findVideoByReferenceId = function findVideoByReferenceId(referenceId, options, callback) {
 
 	var opts = options || new Options();
 	opts.reference_id = referenceId;
 
-	return this.makeRequest(this.commands.read.find_video_by_reference_id, opts, callback);
+	return this.makeRequest(opts.useUnfilteredMethod ? this.commands.read.find_video_by_reference_id_unfiltered : this.commands.read.find_video_by_reference_id, opts, callback);
 }
-
 
 api.prototype.findVideosByReferenceIds = function findVideosByReferenceIds(referenceIds, options, callback) {
 
@@ -328,9 +326,8 @@ api.prototype.findVideosByReferenceIds = function findVideosByReferenceIds(refer
 	if (Array.isArray(referenceIds))
 		opts.reference_ids = referenceIds;
 
-	return this.makeRequest(this.commands.read.find_videos_by_reference_ids, opts, callback);
+	return this.makeRequest(opts.useUnfilteredMethod ? this.commands.read.find_videos_by_reference_ids_unfiltered : this.commands.read.find_videos_by_reference_ids, opts, callback);
 }
-
 
 api.prototype.searchVideos = function searchVideos(all, any, none, exact, options, callback) {
 
@@ -346,15 +343,13 @@ api.prototype.searchVideos = function searchVideos(all, any, none, exact, option
 	if (Array.isArray(none))
 		opts.none = none;	
 
-	return this.makeRequest(this.commands.read.search_videos, opts, callback);
+	return this.makeRequest(opts.useUnfilteredMethod ? this.commands.read.search_videos_unfiltered : this.commands.read.search_videos, opts, callback);
 }
-
 
 api.prototype.findAllPlaylists = function findAllPlaylists(options, callback) {
 
 	return this.makeRequest(this.commands.read.find_all_playlists, options, callback);
 }
-
 
 api.prototype.findPlaylistById = function findPlaylistById(playlistId, options, callback) {
 
@@ -363,7 +358,6 @@ api.prototype.findPlaylistById = function findPlaylistById(playlistId, options, 
 
 	return this.makeRequest(this.commands.read.find_playlist_by_id, opts, callback);
 }
-
 
 api.prototype.findPlaylistsByIds = function findPlaylistsByIds(playlistIds, options, callback) {
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -77,4 +77,9 @@ options.prototype.hlsMediaDelivery = function hlsMediaDelivery() {
 	return this;
 }
 
+options.prototype.includingFiltered = function includingFiltered(toggleBool) {
+	this.useUnfilteredMethod = toggleBool !== undefined ? toggleBool : true
+	return this
+}
+
 module.exports = options;


### PR DESCRIPTION
when a video is inactive or before a scheduled time, bc API will not return the video without calling the [api_name]_unfiltered version. Developers can now add this to return the previously filtered videos:

`mediaApi.withOptions().includingFiltered()`

No breaking API changes, acts as before if the option is not set.
